### PR TITLE
Add cross post indicator when canonical meta exist

### DIFF
--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -1,7 +1,7 @@
 {{#if headerImageUrl}}
-<header id="header" class="hidden-xs" style="background-image: url({{#if headerImageUrl}}{{headerImageUrl}}{{else}}https://code972.com/content/images/header.jpg{{/if}});">
+<header id="header" style="background-image: url({{#if headerImageUrl}}{{headerImageUrl}}{{else}}https://code972.com/content/images/header.jpg{{/if}});">
 {{else}}
-<header id="header" class="hidden-xs">
+<header id="header">
 {{/if}}
   <div class="container">
     <div id="header-title">

--- a/post.hbs
+++ b/post.hbs
@@ -14,6 +14,9 @@
         </div>
         {{/if}}
     </div>
+    {{#if canonicalUrl}}
+        <i class="cross-post">(Cross-posted from <a href="{{canonicalUrl}}">BigData Boutique Blog</a>)</i>
+    {{/if}}
     {{# if post.series}}
     <p>
         This post is part of <a href="{{post.series_url}}">{{post.series}}</a> series.

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -405,6 +405,12 @@ a.social-icon:hover {
             color: #666;
         }
 
+.cross-post {
+    display: block;
+    margin-top: -15px;
+    margin-bottom: 20px;
+}
+
 .date,
 .tags,
 .comments,


### PR DESCRIPTION
Add an indicator of a cross-post when a canonical meta is set (below post timestamp, tags, comment count). Link text is hardcoded as `BigData Boutique Blog` assuming this will only includes cross post from https://blog.bigdataboutique.com/.

![image](https://user-images.githubusercontent.com/3603835/86115225-da461000-baf5-11ea-9796-99834b971dc1.png)  

This PR also includes a fix to header disappearing on mobile.
